### PR TITLE
acu175507 - Add support for :connection_verify_mode

### DIFF
--- a/lib/base/api_manager.rb
+++ b/lib/base/api_manager.rb
@@ -179,6 +179,10 @@ module RightScale
       # @option options [Integer]  :connection_retry_delay
       #  Defines how long we wait on a low level connection error (in seconds)
       #
+      # @option options [Integer]  :connection_verify_mode
+      #  SSL connection cert check: either OpenSSL::SSL::VERIFY_PEER (default) or
+      #  OpenSSL::SSL::VERIFY_NONE
+      #
       # @option options [Hash]  :creds
       #   A set of optional extra creds a cloud may require
       #   (see right_cloud_stack_api gem which supports :tenant_name and :tenant_id)

--- a/lib/base/routines/connection_proxies/right_http_connection_proxy.rb
+++ b/lib/base/routines/connection_proxies/right_http_connection_proxy.rb
@@ -91,7 +91,10 @@ module RightScale
           http_connection_data[:raise_on_timeout]             = @data[:options][:abort_on_timeout]        if @data[:options][:abort_on_timeout]
           http_connection_data[:cert]                         = @data[:credentials][:cert]                if @data[:credentials].has_key?(:cert)
           http_connection_data[:key]                          = @data[:credentials][:key]                 if @data[:credentials].has_key?(:key)
-            
+          if @data[:options].has_key?(:connection_verify_mode)
+            http_connection_data[:use_server_auth] = (@data[:options][:connection_verify_mode] !=  OpenSSL::SSL::VERIFY_NONE)
+          end
+
           #log "HttpConnection request: #{http_connection_data.inspect}"
 
           # Make a request:

--- a/lib/base/routines/connection_proxy.rb
+++ b/lib/base/routines/connection_proxy.rb
@@ -47,8 +47,8 @@ module RightScale
             connection_proxy_class = RightScale::CloudApi::ConnectionProxy::NetHttpPersistentProxy
           end
           @connection_proxy = connection_proxy_class.new
-        end        
-        
+        end
+
         # Register a call back to close current connection
         data[:callbacks][:close_current_connection] = Proc::new do |reason|
           @connection_proxy.close_connection(nil, reason)
@@ -60,7 +60,7 @@ module RightScale
           @connection_proxy.request(data)
         end
       end
-      
+
     end
   end
 end


### PR DESCRIPTION
If :connection_ca_file one provides cannot be verified, the gem raises an SSL auth error.
To workaround the problem one can provide :connection_verify_mode = OpenSSL::SSL::VERIFY_NONE
so that it will work even with unverified certificate.
