### PR TITLE
CF-2631 Fix exception handling in NetHttpPersistentProxy

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,3 +1,9 @@
+== 2017-11-22, v0.2.9
+  - fix a bug with retry in net_http_persistent_proxy
+
+== 2017-01-09, v0.2.8
+  - add retry_after strategy
+
 == 2016-12-05, v0.2.7
   - add method_name to options for routines to use
 

--- a/lib/right_cloud_api_base_version.rb
+++ b/lib/right_cloud_api_base_version.rb
@@ -31,7 +31,7 @@ module RightScale
     # CloudApi gem version namespace
     module VERSION
       # The gem version
-      STRING = '0.2.7'
+      STRING = '0.2.8'
     end
   end
 end

--- a/lib/right_cloud_api_base_version.rb
+++ b/lib/right_cloud_api_base_version.rb
@@ -31,7 +31,7 @@ module RightScale
     # CloudApi gem version namespace
     module VERSION
       # The gem version
-      STRING = '0.2.8'
+      STRING = '0.2.9'
     end
   end
 end


### PR DESCRIPTION
Retry request in the case of getting ‘Address family not supported by protocol’ error(which causes failed pending action and then creating of instance orphan)